### PR TITLE
SO-524 Pass the relation class to where_sql so the correct DB connection is used.

### DIFF
--- a/lib/arsi.rb
+++ b/lib/arsi.rb
@@ -31,7 +31,7 @@ module Arsi
     end
 
     def arel_check!(arel, relation)
-      sql = arel.respond_to?(:ast) ? arel.where_sql(relation.klass) : arel.to_s
+      sql = arel.respond_to?(:ast) ? arel.where_sql(relation&.klass) : arel.to_s
       sql_check!(sql, relation)
     end
 

--- a/lib/arsi.rb
+++ b/lib/arsi.rb
@@ -31,6 +31,7 @@ module Arsi
     end
 
     def arel_check!(arel, relation)
+      return if !@enabled
       sql = arel.respond_to?(:ast) ? arel.where_sql(relation&.klass) : arel.to_s
       sql_check!(sql, relation)
     end

--- a/lib/arsi.rb
+++ b/lib/arsi.rb
@@ -31,7 +31,7 @@ module Arsi
     end
 
     def arel_check!(arel, relation)
-      sql = arel.respond_to?(:ast) ? arel.where_sql : arel.to_s
+      sql = arel.respond_to?(:ast) ? arel.where_sql(relation.klass) : arel.to_s
       sql_check!(sql, relation)
     end
 

--- a/lib/arsi/arel_tree_manager.rb
+++ b/lib/arsi/arel_tree_manager.rb
@@ -7,11 +7,11 @@ module Arsi
 
     # This is from Arel::SelectManager which inherits from Arel::TreeManager.
     # We need where_sql on both Arel::UpdateManager and Arel::DeleteManager so we add it to the parent class.
-    def where_sql(provided_engine = :none)
+    def where_sql(provided_engine)
       return if @ctx.wheres.empty?
 
       selected_engine = provided_engine
-      if selected_engine == :none
+      if selected_engine.nil?
         selected_engine = if AREL_WHERE_SQL_ENGINE_ACCESSOR
           self.engine || ::Arel::Table.engine
         else

--- a/test/arsi_test.rb
+++ b/test/arsi_test.rb
@@ -76,7 +76,7 @@ describe Arsi do
 
   describe "when the model has a different connection" do
     before do
-      Account.establish_connection(adapter: "mysql2", database: "arsi_test_shard", host: "127.0.0.1")
+      Account.establish_connection(adapter: "mysql2", database: "arsi_test", host: "127.0.0.1", username: "root")
       Arel::UpdateManager.any_instance.expects(:where_sql).with(Account).returns("UPDATE `accounts` SET `accounts`.`name` = 'foo' WHERE `accounts`.`id` = ?")
     end
 

--- a/test/arsi_test.rb
+++ b/test/arsi_test.rb
@@ -74,6 +74,18 @@ describe Arsi do
     end
   end
 
+  describe "when the model has a different connection" do
+    before do
+      Account.establish_connection(adapter: "mysql2", database: "arsi_test_shard", host: "127.0.0.1")
+      Arel::UpdateManager.any_instance.expects(:where_sql).with(Account).returns("UPDATE `accounts` SET `accounts`.`name` = 'foo' WHERE `accounts`.`id` = ?")
+    end
+
+    it "connects to the database associated with the relation" do
+      refute_equal Account.connection, ActiveRecord::Base.connection
+      assert Account.where(id: 1).update_all(:name => 'foo')
+    end
+  end
+
   it "allows ActiveRecord::Base#columns" do
     assert User.columns
   end

--- a/test/arsi_test.rb
+++ b/test/arsi_test.rb
@@ -101,6 +101,18 @@ describe Arsi do
     end
   end
 
+  describe "when arsi is disabled" do
+    before do
+      Arsi::UnscopedSQL.expects(:sql_check!).never
+      Arsi.disable!
+    end
+
+    it "does not call sql_check if disabled" do
+      assert User.where(:password => 'hello').delete_all
+      Arsi.enable!
+    end
+  end
+
   it "can be disabled in a block" do
     Arsi.disable do
       assert User.where(:password => 'hello').delete_all

--- a/test/arsi_test.rb
+++ b/test/arsi_test.rb
@@ -75,9 +75,13 @@ describe Arsi do
   end
 
   describe "when the model has a different connection" do
+    let(:wheresql_stub) { stub }
+    let(:viz_stub) { stub }
     before do
       Account.establish_connection(adapter: "mysql2", database: "arsi_test", host: "127.0.0.1", username: "root")
-      Arel::UpdateManager.any_instance.expects(:where_sql).with(Account).returns("UPDATE `accounts` SET `accounts`.`name` = 'foo' WHERE `accounts`.`id` = ?")
+      Arel::Visitors::WhereSql.expects(:new).with(Account.connection.visitor, Account.connection).returns(wheresql_stub)
+      wheresql_stub.expects(:accept).returns(viz_stub)
+      viz_stub.expects(:value).returns("UPDATE `accounts` SET `accounts`.`name` = 'foo' WHERE `accounts`.`id` = ?")
     end
 
     it "connects to the database associated with the relation" do


### PR DESCRIPTION
This commit changed how the DB `engine` was used in arel: https://github.com/rails/arel/commit/98fc25991137ee09b6800578117f8c1c322680f2#diff-04cadafe5127ddc1e59c2d91a190cf970ba8ee064ad62a5eabf358b1c167e80e

Prior to this change, it appeared that `@engine` was set to the model class, whereas after, `engine` is set to `ActiveRecord::Base`.

This would be fine if all models connected to the same database, but they don't for us (via [active_record_shards](https://github.com/zendesk/active_record_shards)).

By passing through the relation `klass` the correct engine=>connection will be used.

@vanchi-zendesk @cubeguerrero @zendesk/ngiyari @zenspider 