### PR TITLE
Return early when arsi is disabled.

### DIFF
--- a/lib/arsi.rb
+++ b/lib/arsi.rb
@@ -31,6 +31,7 @@ module Arsi
     end
 
     def arel_check!(arel, relation)
+      return if !@enabled
       sql = arel.respond_to?(:ast) ? arel.where_sql : arel.to_s
       sql_check!(sql, relation)
     end

--- a/lib/arsi.rb
+++ b/lib/arsi.rb
@@ -31,7 +31,7 @@ module Arsi
     end
 
     def arel_check!(arel, relation)
-      return if !@enabled
+      return unless @enabled
       sql = arel.respond_to?(:ast) ? arel.where_sql : arel.to_s
       sql_check!(sql, relation)
     end

--- a/test/arsi_test.rb
+++ b/test/arsi_test.rb
@@ -85,6 +85,18 @@ describe Arsi do
     end
   end
 
+  describe "when arsi is disabled" do
+    before do
+      Arsi::UnscopedSQL.expects(:sql_check!).never
+      Arsi.disable!
+    end
+
+    it "does not call sql_check if disabled" do
+      assert User.where(:password => 'hello').delete_all
+      Arsi.enable!
+    end
+  end
+
   it "can be disabled in a block" do
     Arsi.disable do
       assert User.where(:password => 'hello').delete_all

--- a/test/arsi_test.rb
+++ b/test/arsi_test.rb
@@ -91,9 +91,12 @@ describe Arsi do
       Arsi.disable!
     end
 
+    after do
+      Arsi.enable!
+    end
+
     it "does not call sql_check if disabled" do
       assert User.where(:password => 'hello').delete_all
-      Arsi.enable!
     end
   end
 


### PR DESCRIPTION
#17 hasn't yet addresses all the issues we're seeing. 
While we work on the fix we want to disable arsi globally. Without this change, connections are still being made to the database which means the `ActiveRecord::StatementInvalid: Mysql2::Error: Table doesn't exist` error is still surfacing.

@grosser @zenspider @vanchi-zendesk @cubeguerrero 