### PR TITLE
Remove alias-chain necessary for Rails 4.0

### DIFF
--- a/lib/arsi/relation.rb
+++ b/lib/arsi/relation.rb
@@ -22,13 +22,8 @@ module Arsi
       with_relation_in_connection { super }
     end
 
-    def self.prepended(base)
-      base.class_eval do
-        alias_method :update_all_without_arsi, :update_all
-        def update_all(*args)
-          with_relation_in_connection { update_all_without_arsi(*args) }
-        end
-      end
+    def update_all(*)
+      with_relation_in_connection { super }
     end
 
     private


### PR DESCRIPTION
The `self.prepended` / alias_method wrapper was added in 48e14c2930e4454093c6f0e31c84808929a7c63e when Rails 4.0 compatibility was added. [A PR comment](https://github.com/zendesk/arsi/pull/8) clarifies that we cannot simply call `super` because

> ends up in an infinite loop because deprecated finders also hacks the same method

Assuming that "deprecated finders" refer to [the "activerecord-deprecated_finders" gem](https://github.com/rails/activerecord-deprecated_finders/blob/041c83c9dce8e17b8e1216adfaff48cc9debac02/lib/active_record/deprecated_finders/relation.rb#L173), then yes, the ARSI gem is no longer compatible with it.