### PR TITLE
Bump to v1.0.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,6 @@
 name: CI
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: push
+
 jobs:
   build:
     name: ruby${{ matrix.ruby }} rails${{ matrix.rails }} rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    arsi (0.4.3)
+    arsi (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       arel
       mysql2

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    arsi (0.4.3)
+    arsi (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       arel
       mysql2

--- a/gemfiles/rails51.gemfile.lock
+++ b/gemfiles/rails51.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    arsi (0.4.3)
+    arsi (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       arel
       mysql2

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    arsi (0.4.3)
+    arsi (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       arel
       mysql2

--- a/lib/arsi/version.rb
+++ b/lib/arsi/version.rb
@@ -1,3 +1,3 @@
 module Arsi
-  VERSION = '0.4.3'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
The gem is over 6 years old and hasn't reached v1.0.0 yet?

Since removing support for Ruby 2.4 and below is a breaking change, I think now is a good time to make that v1.0.0 release.