### PR TITLE
Do not patch _update_record

### DIFF
--- a/lib/arsi/relation.rb
+++ b/lib/arsi/relation.rb
@@ -18,10 +18,6 @@ module Arsi
       !arsi_scopeable?
     end
 
-    def _update_record(*)
-      with_relation_in_connection { super }
-    end
-
     def delete_all(*)
       with_relation_in_connection { super }
     end


### PR DESCRIPTION
Why do we patch `Relation#_update_record`?

Also: `Relation#update_record` is removed between 5.1 and 5.2